### PR TITLE
Add mounted volume & bash entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,3 +34,6 @@ COPY nginx.conf /etc/nginx/conf.d/circulation.conf
 COPY uwsgi.ini uwsgi.ini
 
 EXPOSE 80
+
+VOLUME /var/www/circulation
+ENTRYPOINT ["/bin/bash"]


### PR DESCRIPTION
This gives the container's host direct access to the files created in `/var/www/circulation` and sets the bash shell as the default when you pop in interactively.
