### PR TITLE
Add bibliographic coverage jobs; remove LIBSIMPLE_DIR variable

### DIFF
--- a/deploy/uwsgi.ini
+++ b/deploy/uwsgi.ini
@@ -18,7 +18,7 @@ chmod-socket = 666
 logto = /var/www/circulation/%n.log
 log-format = %(addr) - - [%(ltime)] "%(method) %(uri) %(proto)" %(status) %(size) "%(referer)" "%(uagent)" host_hdr=%(host) req_time_elapsed=%(msecs)
 
-processes = 10
+processes = 6
 harakiri = 300
 lazy-apps = true
 touch-reload=uwsgi.ini

--- a/deploy/uwsgi.ini
+++ b/deploy/uwsgi.ini
@@ -19,6 +19,7 @@ logto = /var/www/circulation/%n.log
 log-format = %(addr) - - [%(ltime)] "%(method) %(uri) %(proto)" %(status) %(size) "%(referer)" "%(uagent)" host_hdr=%(host) req_time_elapsed=%(msecs)
 
 processes = 6
+threads = 2
 harakiri = 300
 lazy-apps = true
 touch-reload=uwsgi.ini

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,5 +1,4 @@
 FROM nypl/circ-base
-ENV LIBSIMPLE_DIR=/var/www/circulation
 ENV TZ=US/Eastern
 
 MAINTAINER Library Simplified <info@librarysimplified.org>

--- a/scripts/libsimple_crontab
+++ b/scripts/libsimple_crontab
@@ -10,14 +10,12 @@ HOME=/var/www/circulation
 # m h dom mon dow user command
 */15 * * * * root core/bin/run axis_monitor >> /var/log/cron.log 2>&1
 */15 * * * * root core/bin/run axis_reaper >> /var/log/cron.log 2>&1
-*/20 * * * * root core/bin/run axis_bibliographic_coverage >> /var/log/cron.log 2>&1
 */15 * * * * root core/bin/run threem_monitor >> /var/log/cron.log 2>&1
 */15 * * * * root core/bin/run threem_circulation_sweep >> /var/log/cron.log 2>&1
-*/20 * * * * root core/bin/run 3m_bibliographic_coverage >> /var/log/cron.log 2>&1
 */15 * * * * root core/bin/run overdrive_monitor_full >> /var/log/cron.log 2>&1
 */15 * * * * root core/bin/run overdrive_monitor_recent >> /var/log/cron.log 2>&1
 */15 * * * * root core/bin/run overdrive_reaper >> /var/log/cron.log 2>&1
-*/20 * * * * root core/bin/run overdrive_bibliographic_coverage >> /var/log/cron.log 2>&1
+*/20 * * * * root core/bin/run bibliographic_coverage >> /var/log/cron.log 2>&1
 */5 * * * * root core/bin/run cache_opds_blocks >> /var/log/cron.log 2>&1
 */10 * * * * root core/bin/run metadata_wrangler_coverage >> /var/log/cron.log 2>&1
 * */6 * * * root core/bin/run refresh_materialized_views >> /var/log/cron.log 2>&1

--- a/scripts/libsimple_crontab
+++ b/scripts/libsimple_crontab
@@ -10,11 +10,14 @@ HOME=/var/www/circulation
 # m h dom mon dow user command
 */15 * * * * root core/bin/run axis_monitor >> /var/log/cron.log 2>&1
 */15 * * * * root core/bin/run axis_reaper >> /var/log/cron.log 2>&1
+*/20 * * * * root core/bin/run axis_bibliographic_coverage >> /var/log/cron.log 2>&1
 */15 * * * * root core/bin/run threem_monitor >> /var/log/cron.log 2>&1
 */15 * * * * root core/bin/run threem_circulation_sweep >> /var/log/cron.log 2>&1
+*/20 * * * * root core/bin/run 3m_bibliographic_coverage >> /var/log/cron.log 2>&1
 */15 * * * * root core/bin/run overdrive_monitor_full >> /var/log/cron.log 2>&1
 */15 * * * * root core/bin/run overdrive_monitor_recent >> /var/log/cron.log 2>&1
 */15 * * * * root core/bin/run overdrive_reaper >> /var/log/cron.log 2>&1
+*/20 * * * * root core/bin/run overdrive_bibliographic_coverage >> /var/log/cron.log 2>&1
 */5 * * * * root core/bin/run cache_opds_blocks >> /var/log/cron.log 2>&1
 */10 * * * * root core/bin/run metadata_wrangler_coverage >> /var/log/cron.log 2>&1
 * */6 * * * root core/bin/run refresh_materialized_views >> /var/log/cron.log 2>&1


### PR DESCRIPTION
This is a bit of a hodge-podge. It:
- lowers the initial number of UWSGI processes to avoid strange memory issues I've run into on my AWS tests (though it may also need threads now)
- adds the recently uncovered bibliographic scripts
- removes the LIBSIMPLE_DIR environment variable that was very properly set and (as of the impending merge of NYPL-Simplified/server_core#252) is no longer necessary
