### PR TITLE
Turn off merge_slashes -- it prevents books identified by URI from being checked out.

### DIFF
--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -3,6 +3,7 @@ server {
     server_name localhost;
     charset     utf-8;
     client_max_body_size 75M;
+    merge_slashes off;
 
     location / { try_files $uri @circulation; }
     location @circulation {


### PR DESCRIPTION
See https://github.com/NYPL-Simplified/circulation/issues/283
