### PR TITLE
Add README files to represent & track Docker Hub documentation

### DIFF
--- a/base/README.md
+++ b/base/README.md
@@ -1,0 +1,37 @@
+# Supported tags and respective `Dockerfile` links
+
+- `1.0.0`, `latest` [(1.0.0/Dockerfile)](https://github.com/NYPL-Simplified/circulation-docker/blob/master/base/Dockerfile)
+
+Older versions of the Circulation Manager are not currently supported.
+
+This image is updated via [pull requests to the `NYPL-Simplified/circulation-docker` GitHub repo](https://github.com/NYPL-Simplified/circulation-docker/pulls).
+
+## What is the Circulation Manager?
+
+The circulation manager is the main connection between a library's collection and Library Simplified's various client-side applications. It handles user authentication, combines licensed works with open access content from the [OA Content Server](https://github.com/NYPL-Simplified/content_server), pulls in updated book information from the [Metadata Wrangler](https://github.com/NYPL-Simplified/metadata_wrangler), and serves up available books in appropriately organized OPDS feeds.
+
+This particular image builds a foundation for other Circulation Manager containers by acquiring the appropriate version of the codebase, creating a virtual environment, and installing required libraries. It could be successfully used as a base for new build repositories or for light development or exploratory work.
+
+## Using This Image
+You will need:
+- **A configuration file** created using JSON and the keys and values described at length [here](https://github.com/NYPL-Simplified/Simplified/wiki/Configuration). If you're unfamiliar with JSON, we highly recommend taking the time to confirm that your configuration file is valid.
+
+With your configuration file stored on the host, you are ready to run:
+```
+$ docker run --name base -it \
+    -v FULL_PATH_TO_YOUR_CONFIGURATION_FILE:/var/www/circulation/config.json \
+    nypl/circ-base
+```
+
+You will need to detach from the generated TTY with `Ctrl`+P, `Ctrl`+Q to keep your container running.
+
+For troubleshooting information and installation directions for the entire Circulation Manager tool suite, please review [the full deployment instructions](https://github.com/NYPL-Simplified/Simplified/wiki/Deployment:-Quickstart-with-Docker).
+
+## Contributing
+
+We welcome your contributions to new features, fixes, or updates, large or small; we are always thrilled to receive pull requests, and do our best to process them as fast as we can.
+
+Before you start to code, we recommend discussing your plans through a [GitHub issue](https://github.com/NYPL-Simplified/circulation-docker/issues/new), especially for more ambitious contributions. This gives other contributors a chance to point you in the right direction, give you feedback on your design, and help you find out if someone else is working on the same thing.
+
+
+(**Note:** This README is intended to directly reflect [the documentation on Docker Hub](https://hub.docker.com/r/nypl/circ-base/).)

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,42 @@
+# Supported tags and respective `Dockerfile` links
+
+- `1.0.0`, `latest` [(1.0.0/Dockerfile)](https://github.com/NYPL-Simplified/circulation-docker/blob/master/deploy/Dockerfile)
+
+Older versions of the Circulation Manager are not currently supported.
+
+This image is updated via [pull requests to the `NYPL-Simplified/circulation-docker` GitHub repo](https://github.com/NYPL-Simplified/circulation-docker/pulls).
+
+## What is the Circulation Manager?
+
+The circulation manager is the main connection between a library's collection and Library Simplified's various client-side applications. It handles user authentication, combines licensed works with open access content from the [OA Content Server](https://github.com/NYPL-Simplified/content_server), pulls in updated book information from the [Metadata Wrangler](https://github.com/NYPL-Simplified/metadata_wrangler), and serves up available books in appropriately organized OPDS feeds.
+
+This particular image builds containers to deploy the Circulation Manager API [using Nginx and uWSGI](https://github.com/NYPL-Simplified/Simplified/wiki/Deployment:-Nginx-&-uWSGI).
+
+## Using This Image
+You will need:
+- **A configuration file** created using JSON and the keys and values described at length [here](https://github.com/NYPL-Simplified/Simplified/wiki/Configuration). If you're unfamiliar with JSON, we highly recommend taking the time to confirm that your configuration file is valid.
+- **An exposed port 80** on your host machine.
+- **A hosted elasticsearch v1 instance**, included in your configuration file. You may choose to use Docker to host this instance. If so, further instructions can be found [here](https://github.com/NYPL-Simplified/Simplified/wiki/Deployment:-Quickstart-with-Docker).
+
+With your the exposed port and the complete configuration file stored on the host, you are ready to run:
+```
+$ docker run --name deploy \
+    -d -p 80:80 \
+    -v FULL_PATH_TO_YOUR_CONFIGURATION_FILE:/var/www/circulation/config.json \
+    nypl/circ-deploy
+```
+
+For troubleshooting information and installation directions for the entire Circulation Manager tool suite, please review [the full deployment instructions](https://github.com/NYPL-Simplified/Simplified/wiki/Deployment:-Quickstart-with-Docker).
+
+## Additional Configuration
+
+If you would like to use different tools to handle deployment for the LS Circulation Manager, you are more than welcome to do so! We would love to support more deployment configurations; feel free to contribute any changes you may make to [the official Docker build repository](https://github.com/NYPL-Simplified/circulation-docker)!
+
+## Contributing
+
+We welcome your contributions to new features, fixes, or updates, large or small; we are always thrilled to receive pull requests, and do our best to process them as fast as we can.
+
+Before you start to code, we recommend discussing your plans through a [GitHub issue](https://github.com/NYPL-Simplified/circulation-docker/issues/new), especially for more ambitious contributions. This gives other contributors a chance to point you in the right direction, give you feedback on your design, and help you find out if someone else is working on the same thing.
+
+
+(**Note:** This README is intended to directly reflect [the documentation on Docker Hub](https://hub.docker.com/r/nypl/circ-deploy/).)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,51 @@
+# Supported tags and respective `Dockerfile` links
+
+- `1.0.0`, `latest` [(1.0.0/Dockerfile)](https://github.com/NYPL-Simplified/circulation-docker/blob/master/scripts/Dockerfile)
+
+Older versions of the Circulation Manager are not currently supported.
+
+This image is updated via [pull requests to the `NYPL-Simplified/circulation-docker` GitHub repo](https://github.com/NYPL-Simplified/circulation-docker/pulls).
+
+## What is the Circulation Manager?
+
+The circulation manager is the main connection between a library's collection and Library Simplified's various client-side applications. It handles user authentication, combines licensed works with open access content from the [OA Content Server](https://github.com/NYPL-Simplified/content_server), pulls in updated book information from the [Metadata Wrangler](https://github.com/NYPL-Simplified/metadata_wrangler), and serves up available books in appropriately organized OPDS feeds.
+
+This particular image builds containers to handle automated scripts on the Circulation Manager, at [the recommended times and frequencies](https://github.com/NYPL-Simplified/Simplified/wiki/AutomatedJobs#circulation-manager).
+
+## Using This Image
+You will need:
+- **A configuration file** created using JSON and the keys and values described at length [here](https://github.com/NYPL-Simplified/Simplified/wiki/Configuration). If you're unfamiliar with JSON, we highly recommend taking the time to confirm that your configuration file is valid.
+- **Your local timezone**, selected according to [Debian-system timezone options](http://manpages.ubuntu.com/manpages/saucy/man3/DateTime::TimeZone::Catalog.3pm.html). This will allow timed scripts intended to run at hours of low usage to run in accordance with your local time.
+
+With your time zone value and the configuration file stored on the host, you are ready to run:
+```
+$ docker run --name scripts \
+    -d -e TZ="YOUR_TIMEZONE_STRING" \
+    -v FULL_PATH_TO_YOUR_CONFIGURATION_FILE:/var/www/circulation/config.json \
+    nypl/circ-scripts
+```
+
+For troubleshooting information and installation directions for the entire Circulation Manager tool suite, please review [the full deployment instructions](https://github.com/NYPL-Simplified/Simplified/wiki/Deployment:-Quickstart-with-Docker).
+
+## Additional Configuration
+
+If you are familiar with the LS Circulation Manager's automated job processes and would like to incorporate your own crontab, you are welcome to do so. If your changes won't overlap with existing scripts, it can be copied into a running container as follows:
+`$ docker cp PATH_TO_YOUR_NEW_CRONTAB scripts:/etc/cron.d/`
+
+However, if you intend to replace the existing crontab, you will need to add the file as a new container:
+```
+$ docker run --name scripts \
+    -d -e TZ="YOUR_TIMEZONE_STRING" \
+    -v FULL_PATH_TO_YOUR_CONFIGURATION_FILE:/var/www/circulation/config.json \
+    -v FULL_PATH_TO_YOUR_NEW_CRONTAB scripts:/etc/cron.d/circulation \
+    nypl/circ-scripts
+```
+
+## Contributing
+
+We welcome your contributions to new features, fixes, or updates, large or small; we are always thrilled to receive pull requests, and do our best to process them as fast as we can.
+
+Before you start to code, we recommend discussing your plans through a [GitHub issue](https://github.com/NYPL-Simplified/circulation-docker/issues/new), especially for more ambitious contributions. This gives other contributors a chance to point you in the right direction, give you feedback on your design, and help you find out if someone else is working on the same thing.
+
+
+(**Note:** This README is intended to directly reflect [the documentation on Docker Hub](https://hub.docker.com/r/nypl/circ-scripts/).)


### PR DESCRIPTION
These README files are exact copies of the new documentation on Docker Hub, but for the final note saying as much.

To review the documentation on Docker Hub, feel free to visit them at home:
- base: https://hub.docker.com/r/nypl/circ-base/
- deploy: https://hub.docker.com/r/nypl/circ-deploy/
- scripts: https://hub.docker.com/r/nypl/circ-scripts/

Fixes #16.
