### PR TITLE
Mount config dir

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -21,7 +21,7 @@ COPY post-receive.sample .git/hooks
 
 # Set up the virtual environment and install python libraries
 RUN virtualenv env && \
-    echo "export SIMPLIFIED_CONFIGURATION_FILE=\"/var/www/circulation/config.json\"" >> env/bin/activate
+    echo "export SIMPLIFIED_CONFIGURATION_FILE=\"/etc/circulation/config.json\"" >> env/bin/activate
 RUN /bin/bash -c 'source env/bin/activate && pip install -r requirements.txt && python -m textblob.download_corpora'
 RUN mv /root/nltk_data /usr/lib/
 

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -25,5 +25,4 @@ RUN virtualenv env && \
 RUN /bin/bash -c 'source env/bin/activate && pip install -r requirements.txt && python -m textblob.download_corpora'
 RUN mv /root/nltk_data /usr/lib/
 
-VOLUME /var/www/circulation
 ENTRYPOINT ["/bin/bash"]

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -14,6 +14,7 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime
 # Create cron tasks & logfile
 RUN touch /var/log/cron.log
 COPY libsimple_crontab /etc/cron.d/circulation
+VOLUME /var/log
 
 WORKDIR bin
 


### PR DESCRIPTION
This branch mounts a directory containing the configuration file instead of mounting only the individual configuration file. This is because AWS ECS doesn't support the mounting of individual files.

This change requires an update to the deployment command in [the documentation](https://github.com/NYPL-Simplified/Simplified/wiki/Deployment:-Quickstart-with-Docker), as follows:
- Step 2 of [the local prep instructions]() should become markdown like:
  ```md
  2. Name your file `config.json` and **put it on your production server** at
    `/etc/libsimple`. (You can put the file in any empty, unused directory you'd like *except
    for `/var/www` or `/var/www/circulation`*, but you'll need to change the value in the
    commands below accordingly.) For the rest of the instructions, we'll be working on this server.
  ```
- For the scripting build, the run command becomes:
  ```sh
  $ sudo docker run -d --name circ-scripts \
      -e TZ="US/Central" \
      -v /etc/libsimple:/etc/circulation \
      nypl/circ-scripts
  ```
- For the api build, the run command changes similarly:
  ```sh
    $ sudo docker run -d -p 80:80 --name circ-deploy \
      -v /etc/libsimple:/etc/circulation \
      nypl/circ-deploy
  ```

Fixes #23.