### PR TITLE
Create image from branch

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -2,6 +2,7 @@ FROM python:2.7
 MAINTAINER Library Simplified <info@librarysimplified.org>
 
 ARG version
+ARG tags="t"
 
 # Development libraries we'll need on top of python:2.7
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -15,8 +16,20 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /var/www
 RUN git clone https://github.com/NYPL-Simplified/circulation.git
 WORKDIR circulation
-RUN git checkout tags/$version
-RUN /bin/bash -c 'git config submodule.core.url https://github.com/NYPL-Simplified/server_core.git && git submodule update --init --recursive'
+
+# Assume we're building for a tagged commit of circulation, but also
+# allow for branches or straight-up SHAs if --build-args tags=f is used
+# at build time.
+RUN /bin/bash -c 'if [[ "$tags" == "t" ]];\
+        then git checkout tags/"$version";\
+        else git checkout "$version"; fi'
+
+# Use an https link for the server_core submodule to avoid and update
+# the submodule for this version.
+RUN /bin/bash -c 'git config submodule.core.url \
+        https://github.com/NYPL-Simplified/server_core.git \
+        && git submodule update --init --recursive'
+
 COPY post-receive.sample .git/hooks
 
 # Set up the virtual environment and install python libraries

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -30,12 +30,19 @@ RUN /bin/bash -c 'git config submodule.core.url \
         https://github.com/NYPL-Simplified/server_core.git \
         && git submodule update --init --recursive'
 
+# Copy a bit o' code that you might want if you want to deploy via git push.
 COPY post-receive.sample .git/hooks
 
-# Set up the virtual environment and install python libraries
+# Pass the mounted configuration file into the environment.
 RUN virtualenv env && \
     echo "export SIMPLIFIED_CONFIGURATION_FILE=\"/etc/circulation/config.json\"" >> env/bin/activate
-RUN /bin/bash -c 'source env/bin/activate && pip install -r requirements.txt && python -m textblob.download_corpora'
+
+# Install required python libraries.
+RUN /bin/bash -c 'source env/bin/activate && \
+        pip install -r requirements.txt && \
+        python -m textblob.download_corpora'
 RUN mv /root/nltk_data /usr/lib/
 
+# If you launch the container interactively with `docker run -it`,
+# this is where you'll end up:
 ENTRYPOINT ["/bin/bash"]

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -2,7 +2,6 @@ FROM python:2.7
 MAINTAINER Library Simplified <info@librarysimplified.org>
 
 ARG version
-ARG tags="t"
 
 # Development libraries we'll need on top of python:2.7
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -17,12 +16,8 @@ WORKDIR /var/www
 RUN git clone https://github.com/NYPL-Simplified/circulation.git
 WORKDIR circulation
 
-# Assume we're building for a tagged commit of circulation, but also
-# allow for branches or straight-up SHAs if --build-args tags=f is used
-# at build time.
-RUN /bin/bash -c 'if [[ "$tags" == "t" ]];\
-        then git checkout tags/"$version";\
-        else git checkout "$version"; fi'
+# Build the requested version of the codebase.
+RUN git checkout "$version"
 
 # Use an https link for the server_core submodule to avoid and update
 # the submodule for this version.


### PR DESCRIPTION
Up until this branch, we could only create a base image from a tag. The changes here allow docker containers to be created against a particular branch of commit SHA instead.

Also: some more verbose documentation and a good number of whitespace changes.