### PR TITLE
Update READMEs / DockerHub configuration

### DIFF
--- a/base/README.md
+++ b/base/README.md
@@ -1,6 +1,7 @@
 # Supported tags and respective `Dockerfile` links
 
-- `1.1.23`, `1.1`, `latest` [(1.1.23/Dockerfile)](https://github.com/NYPL-Simplified/circulation-docker/blob/master/base/Dockerfile)
+- `2.0.0` **(untested)** [(2.0.0/Dockerfile)](https://github.com/NYPL-Simplified/circulation-docker/blob/2ca39e4/base/Dockerfile)
+- `1.1.23`, `1.1`, `latest` [(1.1.23/Dockerfile)](https://github.com/NYPL-Simplified/circulation-docker/blob/2ca39e4/base/Dockerfile)
 
 Older versions of the Circulation Manager are not currently supported.
 

--- a/base/README.md
+++ b/base/README.md
@@ -1,11 +1,21 @@
 # Supported tags and respective `Dockerfile` links
 
-- `1.1.20`, `1.1`, `latest` [(1.0.0/Dockerfile)](https://github.com/NYPL-Simplified/circulation-docker/blob/master/base/Dockerfile)
-- `1.0`
+- `1.1.23`, `1.1`, `latest` [(1.1.23/Dockerfile)](https://github.com/NYPL-Simplified/circulation-docker/blob/master/base/Dockerfile)
 
 Older versions of the Circulation Manager are not currently supported.
 
 This image is updated via [pull requests to the `NYPL-Simplified/circulation-docker` GitHub repo](https://github.com/NYPL-Simplified/circulation-docker/pulls).
+
+#### Contents:
+- What is the Circulation Manager?
+- Using This Image
+  - Version 2.x
+  - Version 1.1.x
+- Environment Variables
+- Notes on Earlier Version
+- Contributing
+
+---
 
 ## What is the Circulation Manager?
 
@@ -14,19 +24,70 @@ The circulation manager is the main connection between a library's collection an
 This particular image builds a foundation for other Circulation Manager containers by acquiring the appropriate version of the codebase, creating a virtual environment, and installing required libraries. It could be successfully used as a base for new build repositories or for light development or exploratory work.
 
 ## Using This Image
+### Version 2.x
+You will need:
+- **A PostgreSQL instance url** in the format `postgres://[username]:[password]@[host]:[port]/[database_name]`
+
+With your PostgreSQL url, you are ready to run:
+```
+# See the section "Environment Variables" below for more information
+# about the values listed here and their alternatives.
+$ docker run --name base -it \
+    -e SIMPLIFIED_DB_TASK='init' \
+    -e SIMPLIFIED_PRODUCTION_DB='postgres://[username]:[password]@[host]:[port]/[database_name]' \
+    nypl/circ-base:2.0
+```
+
+Navigate to `http://localhost/admin` to in your browser to input or update configuration information. If you have not yet created an admin authorization protocol before, you'll need to do that before you can set other configuration.
+
+### Version 1.1.x
 You will need:
 - **A configuration file** created using JSON and the keys and values described at length [here](https://github.com/NYPL-Simplified/Simplified/wiki/Configuration). If you're unfamiliar with JSON, we highly recommend taking the time to confirm that your configuration file is valid.
 
 With your configuration file stored on the host, you are ready to run:
 ```
+# See the section "Environment Variables" below for more information
+# about the values listed here.
 $ docker run --name base -it \
     -v FULL_PATH_TO_YOUR_CONFIGURATION_FILE_DIRECTORY:/etc/circulation \
-    nypl/circ-base
+    -v SIMPLIFIED_CONFIGURATION_FILE='/etc/circulation/config.json'
+    -v SIMPLIFIED_DB_TASK='migrate' \
+    nypl/circ-base:1.1
 ```
 
 You will need to detach from the generated TTY with `Ctrl`+P, `Ctrl`+Q to keep your container running.
 
 For troubleshooting information and installation directions for the entire Circulation Manager tool suite, please review [the full deployment instructions](https://github.com/NYPL-Simplified/Simplified/wiki/Deployment:-Quickstart-with-Docker).
+
+## Environment Variables
+
+### `SIMPLIFIED_CONFIGURATION_FILE`
+
+*Required in v1.1 only. Optional in v2.x.* The full path to configuration file in the container. Using the volume `-v` for v1.1, it should look something like `/etc/circulation/YOUR_CONFIGURATION_FILENAME.json`. In v2.x you can volume it in wherever you'd like.
+
+Use [this documentation](https://github.com/NYPL-Simplified/Simplified/wiki/Configuration) to create the JSON file for your particular library's configuration. If you're unfamiliar with JSON, you can use [this JSON Formatter & Validator](https://jsonformatter.curiousconcept.com/#) to validate your configuration file.
+
+### `SIMPLIFIED_DB_TASK`
+
+*Required.* Performs a task against the database at container runtime. Options are:
+  - `ignore` : Does nothing. This is the default value.
+  - `init` : Initializes the app against a brand new database. If you are running a circulation manager for the first time every, use this value to set up an Elasticsearch alias and account for the database schema for future migrations.
+  - `migrate` : Migrates an existing database against a new release. Use this value when switching from one stable version to another.
+
+### `SIMPLIFIED_PRODUCTION_DATABASE`
+
+*Required in v2.x only.* The URL of the production PostgreSQL database for the application.
+
+### `SIMPLIFIED_TEST_DATABASE`
+
+*Optional in v2.x only.* The URL of a PostgreSQL database for tests. This optional variable allows unit tests to be run in the container.
+
+## Notes on Earlier Versions
+
+Prior to version 1.1.23, The environment variable `LIBSIMPLE_DB_INIT` was used to initialize databases. In these versions, there was no option to migrate databases at all. Migrations against containers created with <=1.1.22 need to be run manually using the following command:
+```
+docker exec scripts /bin/bash -c 'source env/bin/activate && core/bin/migrate_database'
+```
 
 ## Contributing
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,11 +1,22 @@
 # Supported tags and respective `Dockerfile` links
 
-- `1.1.20`, `1.1`, `latest` [(1.1/Dockerfile)](https://github.com/NYPL-Simplified/circulation-docker/blob/master/deploy/Dockerfile)
-- `1.0`
+- `1.1.23`, `1.1`, `latest` [(1.1.23/Dockerfile)](https://github.com/NYPL-Simplified/circulation-docker/blob/master/deploy/Dockerfile)
 
 Older versions of the Circulation Manager are not currently supported.
 
 This image is updated via [pull requests to the `NYPL-Simplified/circulation-docker` GitHub repo](https://github.com/NYPL-Simplified/circulation-docker/pulls).
+
+#### Contents:
+- What is the Circulation Manager?
+- Using This Image
+  - Version 2.x
+  - Version 1.1.x
+- Environment Variables
+- Notes on Earlier Version
+- Additional Configuration
+- Contributing
+
+---
 
 ## What is the Circulation Manager?
 
@@ -14,6 +25,24 @@ The circulation manager is the main connection between a library's collection an
 This particular image builds containers to deploy the Circulation Manager API [using Nginx and uWSGI](https://github.com/NYPL-Simplified/Simplified/wiki/Deployment:-Nginx-&-uWSGI).
 
 ## Using This Image
+### Version 2.x
+You will need:
+- **A PostgreSQL instance url** in the format `postgres://[username]:[password]@[host]:[port]/[database_name]`
+
+With your PostgreSQL url, you are ready to run:
+```
+# See the section "Environment Variables" below for more information
+# about the values listed here and their alternatives.
+$ docker run --name deploy \
+    -d -p 80:80 \
+    -e SIMPLIFIED_DB_TASK='migrate' \
+    -e SIMPLIFIED_PRODUCTION_DB='postgres://[username]:[password]@[host]:[port]/[database_name]' \
+    nypl/circ-deploy:2.0
+```
+
+Navigate to `http://localhost/admin` to in your browser to input or update configuration information. If you have not yet created an admin authorization protocol before, you'll need to do that before you can set other configuration.
+
+### Version 1.1.x
 You will need:
 - **A configuration file** created using JSON and the keys and values described at length [here](https://github.com/NYPL-Simplified/Simplified/wiki/Configuration). If you're unfamiliar with JSON, we highly recommend taking the time to confirm that your configuration file is valid.
 - **An exposed port 80** on your host machine.
@@ -21,14 +50,47 @@ You will need:
 
 With your the exposed port and the complete configuration file stored on the host, you are ready to run:
 ```
+# See the section "Environment Variables" below for more information
+# about the values listed here and their alternatives.
 $ docker run --name deploy \
     -d -p 80:80 \
     -v FULL_PATH_TO_YOUR_CONFIGURATION_FILE_DIRECTORY:/etc/circulation \
-    -e LIBSIMPLE_DB_INIT=true \                  # only when using the database for the first time
-    nypl/circ-deploy
+    -e SIMPLIFIED_CONFIGURATION_FILE='/etc/circulation/config.json' \
+    -e SIMPLIFIED_DB_TASK='init' \
+    nypl/circ-deploy:1.1
 ```
 
 For troubleshooting information and installation directions for the entire Circulation Manager tool suite, please review [the full deployment instructions](https://github.com/NYPL-Simplified/Simplified/wiki/Deployment:-Quickstart-with-Docker).
+
+## Environment Variables
+
+### `SIMPLIFIED_CONFIGURATION_FILE`
+
+*Required in v1.1 only. Optional in v2.x.* The full path to configuration file in the container. Using the volume `-v` for v1.1, it should look something like `/etc/circulation/YOUR_CONFIGURATION_FILENAME.json`. In v2.x you can volume it in wherever you'd like.
+
+Use [this documentation](https://github.com/NYPL-Simplified/Simplified/wiki/Configuration) to create the JSON file for your particular library's configuration. If you're unfamiliar with JSON, you can use [this JSON Formatter & Validator](https://jsonformatter.curiousconcept.com/#) to validate your configuration file.
+
+### `SIMPLIFIED_DB_TASK`
+
+*Required.* Performs a task against the database at container runtime. Options are:
+  - `ignore` : Does nothing. This is the default value.
+  - `init` : Initializes the app against a brand new database. If you are running a circulation manager for the first time every, use this value to set up an Elasticsearch alias and account for the database schema for future migrations.
+  - `migrate` : Migrates an existing database against a new release. Use this value when switching from one stable version to another.
+
+### `SIMPLIFIED_PRODUCTION_DATABASE`
+
+*Required in v2.x only.* The URL of the production PostgreSQL database for the application.
+
+### `SIMPLIFIED_TEST_DATABASE`
+
+*Optional in v2.x only.* The URL of a PostgreSQL database for tests. This optional variable allows unit tests to be run in the container.
+
+## Notes on Earlier Versions
+
+Prior to version 1.1.23, The environment variable `LIBSIMPLE_DB_INIT` was used to initialize databases. In these versions, there was no option to migrate databases at all. Migrations against containers created with <=1.1.22 need to be run manually using the following command:
+```
+docker exec scripts /bin/bash -c 'source env/bin/activate && core/bin/migrate_database'
+```
 
 ## Additional Configuration
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,6 +1,7 @@
 # Supported tags and respective `Dockerfile` links
 
-- `1.1.23`, `1.1`, `latest` [(1.1.23/Dockerfile)](https://github.com/NYPL-Simplified/circulation-docker/blob/master/deploy/Dockerfile)
+- `2.0.0` **(untested)** [(2.0.0/Dockerfile)](https://github.com/NYPL-Simplified/circulation-docker/blob/2ca39e4/deploy/Dockerfile)
+- `1.1.23`, `1.1`, `latest` [(1.1.23/Dockerfile)](https://github.com/NYPL-Simplified/circulation-docker/blob/2ca39e4/deploy/Dockerfile)
 
 Older versions of the Circulation Manager are not currently supported.
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,11 +1,22 @@
 # Supported tags and respective `Dockerfile` links
 
-- `1.1.20`, `1.1`, `latest` [(1.1.20/Dockerfile)](https://github.com/NYPL-Simplified/circulation-docker/blob/master/scripts/Dockerfile)
-- `1.0`
+- `1.1.23`, `1.1`, `latest` [(1.1.23/Dockerfile)](https://github.com/NYPL-Simplified/circulation-docker/blob/master/scripts/Dockerfile)
 
 Older versions of the Circulation Manager are not currently supported.
 
 This image is updated via [pull requests to the `NYPL-Simplified/circulation-docker` GitHub repo](https://github.com/NYPL-Simplified/circulation-docker/pulls).
+
+#### Contents:
+- What is the Circulation Manager?
+- Using This Image
+  - Version 2.x
+  - Version 1.1.x
+- Environment Variables
+- Notes on Earlier Version
+- Additional Configuration
+- Contributing
+
+---
 
 ## What is the Circulation Manager?
 
@@ -14,20 +25,76 @@ The circulation manager is the main connection between a library's collection an
 This particular image builds containers to handle automated scripts on the Circulation Manager, at [the recommended times and frequencies](https://github.com/NYPL-Simplified/Simplified/wiki/AutomatedJobs#circulation-manager).
 
 ## Using This Image
+### Version 2.x
+You will need:
+- **A PostgreSQL instance url** in the format `postgres://[username]:[password]@[host]:[port]/[database_name]`
+
+With your PostgreSQL url, you are ready to run:
+```
+# See the section "Environment Variables" below for more information
+# about the values listed here and their alternatives.
+$ docker run --name scripts \
+    -d -p 80:80 \
+    -e TZ='YOUR_TIMEZONE_STRING' \
+    -e SIMPLIFIED_DB_TASK='migrate' \
+    -e SIMPLIFIED_PRODUCTION_DB='postgres://[username]:[password]@[host]:[port]/[database_name]' \
+    nypl/circ-scripts:2.0
+```
+
+Navigate to `http://localhost/admin` to in your browser to input or update configuration information. If you have not yet created an admin authorization protocol before, you'll need to do that before you can set other configuration.
+
+### Version 1.1.x
 You will need:
 - **A configuration file** created using JSON and the keys and values described at length [here](https://github.com/NYPL-Simplified/Simplified/wiki/Configuration). If you're unfamiliar with JSON, we highly recommend taking the time to confirm that your configuration file is valid.
 - **Your local timezone**, selected according to [Debian-system timezone options](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones). This will allow timed scripts intended to run at hours of low usage to run in accordance with your local time.
 
 With your time zone value and the configuration file stored on the host, you are ready to run:
 ```
+# See the section "Environment Variables" below for more information
+# about the values listed here and their alternatives.
 $ docker run --name scripts \
-    -d -e TZ="YOUR_TIMEZONE_STRING" \
-    -e LIBSIMPLE_DB_INIT=true \                  # only when using the database for the first time
+    -d -e TZ='YOUR_TIMEZONE_STRING' \
     -v FULL_PATH_TO_YOUR_CONFIGURATION_FILE_DIRECTORY:/etc/circulation \
-    nypl/circ-scripts
+    -e SIMPLIFIED_CONFIGURATION_FILE='/etc/circulation/config.json' \
+    -e SIMPLIFIED_DB_TASK='init' \
+    nypl/circ-scripts:1.1
 ```
 
 For troubleshooting information and installation directions for the entire Circulation Manager tool suite, please review [the full deployment instructions](https://github.com/NYPL-Simplified/Simplified/wiki/Deployment:-Quickstart-with-Docker).
+
+## Environment Variables
+
+### `SIMPLIFIED_CONFIGURATION_FILE`
+
+*Required in v1.1 only. Optional in v2.x.* The full path to configuration file in the container. Using the volume `-v` for v1.1, it should look something like `/etc/circulation/YOUR_CONFIGURATION_FILENAME.json`. In v2.x you can volume it in wherever you'd like.
+
+Use [this documentation](https://github.com/NYPL-Simplified/Simplified/wiki/Configuration) to create the JSON file for your particular library's configuration. If you're unfamiliar with JSON, you can use [this JSON Formatter & Validator](https://jsonformatter.curiousconcept.com/#) to validate your configuration file.
+
+### `SIMPLIFIED_DB_TASK`
+
+*Required.* Performs a task against the database at container runtime. Options are:
+  - `ignore` : Does nothing. This is the default value.
+  - `init` : Initializes the app against a brand new database. If you are running a circulation manager for the first time every, use this value to set up an Elasticsearch alias and account for the database schema for future migrations.
+  - `migrate` : Migrates an existing database against a new release. Use this value when switching from one stable version to another.
+
+### `SIMPLIFIED_PRODUCTION_DATABASE`
+
+*Required in v2.x only.* The URL of the production PostgreSQL database for the application.
+
+### `SIMPLIFIED_TEST_DATABASE`
+
+*Optional in v2.x only.* The URL of a PostgreSQL database for tests. This optional variable allows unit tests to be run in the container.
+
+### `TZ`
+
+*Optional.* The timezone of the library or libraries on this circulation manager, selected according to [Debian-system timezone options](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones). This value allows scripts to run at ideal times.
+
+## Notes on Earlier Versions
+
+Prior to version 1.1.23, The environment variable `LIBSIMPLE_DB_INIT` was used to initialize databases. In these versions, there was no option to migrate databases at all. Migrations against containers created with <=1.1.22 need to be run manually using the following command:
+```
+docker exec scripts /bin/bash -c 'source env/bin/activate && core/bin/migrate_database'
+```
 
 ## Additional Configuration
 
@@ -38,8 +105,9 @@ However, if you intend to replace the existing crontab, you will need to inject 
 ```
 $ docker run --name scripts \
     -d -e TZ="YOUR_TIMEZONE_STRING" \
-    -v FULL_PATH_TO_YOUR_CONFIGURATION_FILE_DIRECTORY:/etc/circulation \
     -v FULL_PATH_TO_DIRECTORY_WITH_YOUR_NEW_CRONTAB:/etc/cron.d \
+    -v FULL_PATH_TO_YOUR_CONFIGURATION_FILE_DIRECTORY:/etc/circulation \
+    -e SIMPLIFIED_CONFIGURATION_FILE='/etc/circulation/config.json' \
     nypl/circ-scripts
 ```
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,6 +1,7 @@
 # Supported tags and respective `Dockerfile` links
 
-- `1.1.23`, `1.1`, `latest` [(1.1.23/Dockerfile)](https://github.com/NYPL-Simplified/circulation-docker/blob/master/scripts/Dockerfile)
+- `2.0.0` **(untested)** [(2.0.0/Dockerfile)](https://github.com/NYPL-Simplified/circulation-docker/blob/2ca39e4/scripts/Dockerfile)
+- `1.1.23`, `1.1`, `latest` [(1.1.23/Dockerfile)](https://github.com/NYPL-Simplified/circulation-docker/blob/2ca39e4/scripts/Dockerfile)
 
 Older versions of the Circulation Manager are not currently supported.
 


### PR DESCRIPTION
This branch updates the README for each Docker image. These README files are exactly the same as the full image descriptions hosted on Docker Hub. They both support the released version 1.1.23 and also include prepatory commands for the upcoming multi-tenant versions of the circulation manager.

This branch and changes to [the deployment wiki](https://github.com/NYPL-Simplified/Simplified/wiki/Deployment:-Quickstart-with-Docker) fixes #41.