### PR TITLE
Add OPDS monitors to the crontab.

### DIFF
--- a/scripts/libsimple_crontab
+++ b/scripts/libsimple_crontab
@@ -56,7 +56,7 @@ HOME=/var/www/circulation
 # OPDS For Distributors
 #
 0 0 2 * * root core/bin/run opds_for_distributors_reaper_monitor >> /var/log/cron.log 2>&1
-0 4 * * * root core/bin/run opds_for_distributors_monitor >> /var/log/cron.log 2>&1
+0 4 * * * root core/bin/run opds_for_distributors_import_monitor >> /var/log/cron.log 2>&1
 
 # Vanilla OPDS
 #

--- a/scripts/libsimple_crontab
+++ b/scripts/libsimple_crontab
@@ -8,24 +8,56 @@ PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 HOME=/var/www/circulation
 
 # m h dom mon dow user command
+
+# These scripts update internal caches.
+#
+*/5 * * * * root core/bin/run cache_opds_blocks >> /var/log/cron.log 2>&1
+0 */6 * * * root core/bin/run refresh_materialized_views >> /var/log/cron.log 2>&1
+0 4 * * * root core/bin/run update_random_order >> /var/log/cron.log 2>&1
+0 1 * * * root core/bin/run loan_reaper >> /var/log/cron.log 2>&1
+
+# These scripts improve the bibliographic information associated with
+# the collections.
+#
+*/20 * * * * root core/bin/run bibliographic_coverage >> /var/log/cron.log 2>&1
+*/10 * * * * root core/bin/run metadata_wrangler_coverage >> /var/log/cron.log 2>&1
+30 3 * * * root core/bin/run update_nyt_bestseller_lists >> /var/log/cron.log 2>&1
+
+# The remaining scripts keep the circulation manager in sync with
+# specific types of collections.
+
+# Axis 360
+#
 */15 * * * * root core/bin/run axis_monitor >> /var/log/cron.log 2>&1
 */15 * * * * root core/bin/run axis_reaper >> /var/log/cron.log 2>&1
+
+# Bibliotheca
+#
 */15 * * * * root core/bin/run bibliotheca_monitor >> /var/log/cron.log 2>&1
 */15 * * * * root core/bin/run bibliotheca_circulation_sweep >> /var/log/cron.log 2>&1
+
+# Overdrive
+#
 */15 * * * * root core/bin/run overdrive_monitor_full >> /var/log/cron.log 2>&1
 */15 * * * * root core/bin/run overdrive_monitor_recent >> /var/log/cron.log 2>&1
 */15 * * * * root core/bin/run overdrive_reaper >> /var/log/cron.log 2>&1
+0 4 4 * * * root core/bin/run/overdrive_format_sweep >> /var/log/cron.log 2>&1
+
+# RBdigital
+#
 0 */1 * * * root core/bin/run oneclick_library_delta >> /var/log/cron.log 2>&1
 0 */1 * * * root core/bin/run oneclick_monitor_availability >> /var/log/cron.log 2>&1
+
+# Enki
+#
 0 0 1 * * root core/bin/run enki_reaper >> /var/log/cron.log 2>&1
 0 3 * * * root core/bin/run enki_import >> /var/log/cron.log 2>&1
+
+# OPDS For Distributors
+#
 0 0 2 * * root core/bin/run opds_for_distributors_reaper_monitor >> /var/log/cron.log 2>&1
 0 4 * * * root core/bin/run opds_for_distributors_monitor >> /var/log/cron.log 2>&1
+
+# Vanilla OPDS
+#
 0 5 * * * root core/bin/run opds_import_monitor >> /var/log/cron.log 2>&1
-*/20 * * * * root core/bin/run bibliographic_coverage >> /var/log/cron.log 2>&1
-*/5 * * * * root core/bin/run cache_opds_blocks >> /var/log/cron.log 2>&1
-*/10 * * * * root core/bin/run metadata_wrangler_coverage >> /var/log/cron.log 2>&1
-* */6 * * * root core/bin/run refresh_materialized_views >> /var/log/cron.log 2>&1
-* 4 * * * root core/bin/run update_random_order >> /var/log/cron.log 2>&1
-* 3 * * * root core/bin/run update_nyt_bestseller_lists >> /var/log/cron.log 2>&1
-59 23 * * * root core/bin/run content_server_monitor >> /var/log/cron.log 2>&1

--- a/scripts/libsimple_crontab
+++ b/scripts/libsimple_crontab
@@ -19,6 +19,9 @@ HOME=/var/www/circulation
 0 */1 * * * root core/bin/run oneclick_monitor_availability >> /var/log/cron.log 2>&1
 0 0 1 * * root core/bin/run enki_reaper >> /var/log/cron.log 2>&1
 0 3 * * * root core/bin/run enki_import >> /var/log/cron.log 2>&1
+0 0 2 * * root core/bin/run opds_for_distributors_reaper_monitor >> /var/log/cron.log 2>&1
+0 4 * * * root core/bin/run opds_for_distributors_monitor >> /var/log/cron.log 2>&1
+0 5 * * * root core/bin/run opds_import_monitor >> /var/log/cron.log 2>&1
 */20 * * * * root core/bin/run bibliographic_coverage >> /var/log/cron.log 2>&1
 */5 * * * * root core/bin/run cache_opds_blocks >> /var/log/cron.log 2>&1
 */10 * * * * root core/bin/run metadata_wrangler_coverage >> /var/log/cron.log 2>&1


### PR DESCRIPTION
This should fix https://github.com/NYPL-Simplified/circulation-docker/issues/49. The times are more or less random.