### PR TITLE
Make the crontab periodically refresh the search index.

### DIFF
--- a/services/simplified_crontab
+++ b/services/simplified_crontab
@@ -15,6 +15,7 @@ HOME=/var/www/circulation
 0 */6 * * * root core/bin/run refresh_materialized_views >> /var/log/cron.log 2>&1
 0 4 * * * root core/bin/run update_random_order >> /var/log/cron.log 2>&1
 0 1 * * * root core/bin/run loan_reaper >> /var/log/cron.log 2>&1
+*/6 * * * * root core/bin/run search_index_refresh >> /var/log/cron.log 2>&1
 
 # These scripts improve the bibliographic information associated with
 # the collections.


### PR DESCRIPTION
This branch adds to the Docker crontab the script added to circulation in https://github.com/NYPL-Simplified/circulation/pull/726.

Updating the docker submodule on circulation brings in a ton of changes from the past week, so I'm not sure if that's the right thing to do now.