### PR TITLE
Push all versions to Docker Hub

### DIFF
--- a/hooks/post_push
+++ b/hooks/post_push
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -ex
+
+function tag_and_push {
+  # Create a duplicate image with a given tag and push it to Docker Hub.
+  new_tag="$1"
+
+  new_image="$DOCKER_REPO:$new_tag"
+  docker tag "$IMAGE_NAME" "$new_image"
+  docker push "$new_image"
+}
+
+# If this is a version release (e.g. 2.0.7), then also push it with the parent
+# version tag (e.g. 2.0) and the "latest" tag.
+if [[ $SOURCE_BRANCH =~ [0-9]*\.[0-9]*\.[0-9]* ]]; then
+  # Get the shortened version of this same version tag.
+  short_version=$(echo "$SOURCE_BRANCH" | sed -e "s/\([0-9]*\.[0-9]*\)\.[0-9]*/\1/g")
+
+  tag_and_push "$short_version"
+  tag_and_push "latest"
+fi


### PR DESCRIPTION
This branch will push versioned docker containers with two additional tags: a shortened version number and the "latest" tag.

Fixes #52.