### PR TITLE
Changed name and frequency of the RBdigital scripts.

### DIFF
--- a/services/simplified_crontab
+++ b/services/simplified_crontab
@@ -46,8 +46,9 @@ HOME=/var/www/circulation
 
 # RBdigital
 #
-0 */1 * * * root core/bin/run oneclick_library_delta >> /var/log/cron.log 2>&1
-0 */1 * * * root core/bin/run oneclick_monitor_availability >> /var/log/cron.log 2>&1
+0 */4 * * root core/bin/run rbdigital_availability_monitor >> /var/log/cron.log 2>&1
+0 23 * * * root core/bin/run rbdigital_collection_delta >> /var/log/cron.log 2>&1
+0 23 * * root core/bin/run rbdigital_initial_import >> /var/log/cron.log 2>&1
 
 # Enki
 #


### PR DESCRIPTION
This branch renames the RBdigital scripts to names used in https://github.com/NYPL-Simplified/circulation/pull/747/files, reduces the frequency of the delta script and the availability monitor, and adds the huge 'initial import' script to the crontab because otherwise the initial import will never happen. (https://github.com/NYPL-Simplified/server_core/pull/690 ensures that the initial import only happens once per collection).