### PR TITLE
Added a cron entry to run work_classify_unchecked_subjects.

### DIFF
--- a/services/simplified_crontab
+++ b/services/simplified_crontab
@@ -43,7 +43,7 @@ HOME=/var/www/circulation
 
 # If any works are classified under unprocessed subjects, reclassify
 # those works.
-30 22 * * * root core/bin/run work_classify_unchecked_subjects
+30 22 * * * root core/bin/run work_classify_unchecked_subjects >> /var/log/cron.log 2>&1
 
 # The remaining scripts keep the circulation manager in sync with
 # specific types of collections.

--- a/services/simplified_crontab
+++ b/services/simplified_crontab
@@ -41,6 +41,10 @@ HOME=/var/www/circulation
 # identifiers, 25 at a time.
 # */10 * * * * root core/bin/run metadata_wrangler_coverage >> /var/log/cron.log 2>&1
 
+# If any works are classified under unprocessed subjects, reclassify
+# those works.
+30 22 * * * root core/bin/run work_classify_unchecked_subjects
+
 # The remaining scripts keep the circulation manager in sync with
 # specific types of collections.
 


### PR DESCRIPTION
This branch adds a cron entry to run a new script in circulation that reclassifies all Works associated with Subjects where `checked=false`. This makes it easy to handle changes in our classification system during a database migration -- we just mark all the affected Subjects as `checked=false`, and when this script runs it will run all the affected works through the new algorithm.