### PR TITLE
Added a line which hopefully will run core/bin/opds_entry_coverage.

### DIFF
--- a/services/simplified_crontab
+++ b/services/simplified_crontab
@@ -41,6 +41,9 @@ HOME=/var/www/circulation
 # those works.
 30 22 * * * root core/bin/run work_classify_unchecked_subjects >> /var/log/cron.log 2>&1
 
+# If any works have out-of-date OPDS entries, rebuild them,
+40 22 * * * root core/bin/run opds_entry_coverage >> /var/log/cron.log 2>&1
+
 # The remaining scripts keep the circulation manager in sync with
 # specific types of collections.
 


### PR DESCRIPTION
This branch puts `core/bin/opds_entry_coverage` (created by https://github.com/NYPL-Simplified/server_core/pull/767) in the cron.

I'm not sure whether `core/bin/run` will look for a script in `core/bin` as opposed to `bin` so I'm not sure if this will work. I may need to also provide the script in `circulation/bin`.