### PR TITLE
Add db task automation

### DIFF
--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -4,7 +4,7 @@ MAINTAINER Library Simplified <info@librarysimplified.org>
 ARG version
 ARG repo="NYPL-Simplified/circulation"
 
-ENV SIMPLIFIED_DB_TASK "ignore"
+ENV SIMPLIFIED_DB_TASK "auto"
 
 # Copy over all Library Simplified build files for this image
 COPY . /ls_build

--- a/Dockerfile.scripts
+++ b/Dockerfile.scripts
@@ -4,7 +4,7 @@ MAINTAINER Library Simplified <info@librarysimplified.org>
 ARG version
 ARG repo="NYPL-Simplified/circulation"
 
-ENV SIMPLIFIED_DB_TASK "ignore"
+ENV SIMPLIFIED_DB_TASK "auto"
 
 ENV TZ=US/Eastern
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ For troubleshooting information and installation directions for the entire Circu
 ### `SIMPLIFIED_DB_TASK`
 
 *Required.* Performs a task against the database at container runtime. Options are:
-  - `ignore` : Does nothing. This is the default value.
+  - `auto` : Either initializes or migrates the database, depending on if it is new or not. This is the default value.
+  - `ignore` : Does nothing.
   - `init` : Initializes the app against a brand new database. If you are running a circulation manager for the first time every, use this value to set up an Elasticsearch alias and account for the database schema for future migrations.
   - `migrate` : Migrates an existing database against a new release. Use this value when switching from one stable version to another.
 

--- a/startup/02_manage_simplified_database.sh
+++ b/startup/02_manage_simplified_database.sh
@@ -8,6 +8,9 @@ WORKDIR=/var/www/circulation
 BINDIR=$WORKDIR/bin
 CORE_BINDIR=$WORKDIR/core/bin
 
+initialization_task="${BINDIR}/util/initialize_instance"
+migration_task="${CORE_BINDIR}/migrate_database"
+
 su simplified <<EOF
 # Default value 'ignore' does nothing.
 if ! [[ $SIMPLIFIED_DB_TASK == "ignore" ]]; then
@@ -15,13 +18,20 @@ if ! [[ $SIMPLIFIED_DB_TASK == "ignore" ]]; then
   # Enter the virtual environment for the application.
   source $WORKDIR/env/bin/activate;
 
-  if [[ $SIMPLIFIED_DB_TASK == "init" ]] && [[ -f ${BINDIR}/util/initialize_instance ]]; then
-    # Initialize the database with value 'init'
-    ${BINDIR}/util/initialize_instance;
+  if [[ $SIMPLIFIED_DB_TASK == "auto" ]] && [[ -f ${initialization_task} ]] \
+      && [[ -f ${migration_task} ]]; then
+    # Use 'auto' to initialize the database and then migrate it -- accounting
+    # for either starting off an untouched database or keeping an existing one
+    # up to date. This option is great for automated deployment.
+    ${initialization_task} && ${migration_task};
 
-  elif [[ $SIMPLIFIED_DB_TASK == "migrate" ]] && [[ -f ${CORE_BINDIR}/migrate_database ]]; then
+  elif [[ $SIMPLIFIED_DB_TASK == "init" ]] && [[ -f ${initialization_task} ]]; then
+    # Initialize the database with value 'init'
+    ${initialization_task};
+
+  elif [[ $SIMPLIFIED_DB_TASK == "migrate" ]] && [[ -f ${migration_task} ]]; then
     # Migrate the database with value 'migrate'
-    ${CORE_BINDIR}/migrate_database;
+    ${migration_task};
 
   # Raise an error if any other value is sent
   else echo "Unknown database task '${SIMPLIFIED_DB_TASK}' requested" && exit 127;


### PR DESCRIPTION
This branch adds an `auto` option to the list of acceptable `SIMPLIFIED_DB_TASK` environment variables and sets it by default. Using `auto` will either initialize a new database _or_ migrate an existing one, depending on the timestamps existing in database's timestamps table.

As implemented, `auto` first tries to initialize the database (which won't do anything if the database has already been initialized) and then tries to migrate it (which won't make changes if the database has just been initialized).

Fixes #61.