### PR TITLE
Create circ webapp

### DIFF
--- a/Dockerfile.webapp
+++ b/Dockerfile.webapp
@@ -1,0 +1,26 @@
+FROM phusion/baseimage
+MAINTAINER Library Simplified <info@librarysimplified.org>
+
+ARG version
+ARG repo="NYPL-Simplified/circulation"
+
+ENV SIMPLIFIED_DB_TASK "auto"
+
+# Copy over all Library Simplified build files for this image
+COPY . /ls_build
+
+RUN /bin/bash -c "/ls_build/simplified_app.sh ${repo} ${version} \
+      && /ls_build/logrotate.sh \
+      && /ls_build/nginx.sh \
+      && /ls_build/uwsgi.sh \
+      && rm -rf /ls_build && /bd_build/cleanup.sh"
+
+VOLUME /var/log
+WORKDIR /home/simplified/circulation
+EXPOSE 80
+
+CMD ["/sbin/my_init"]
+
+# # If you launch the container interactively with `docker run -it`,
+# # this is where you'll end up:
+# ENTRYPOINT ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -16,25 +16,25 @@ These are the Docker images for Library Simplified's [Circulation Manager](https
 The circulation manager is the main connection between a library's collection and Library Simplified's various client-side applications. It handles user authentication, combines licensed works with open access content from the [OA Content Server](https://github.com/NYPL-Simplified/content_server), pulls in updated book information from the [Metadata Wrangler](https://github.com/NYPL-Simplified/metadata_wrangler), and serves up available books in appropriately organized OPDS feeds.
 
 The Dockerfiles in this directory create two distinct but necessary containers to deploy the Circulation Manager:
-  - `circ-deploy`: a container that deploys the API [using Nginx and uWSGI](https://github.com/NYPL-Simplified/Simplified/wiki/Deployment:-Nginx-&-uWSGI)
+  - `circ-webapp` (**deprecated:** `circ-deploy`): a container that launches the API and admin interface [using Nginx and uWSGI](https://github.com/NYPL-Simplified/Simplified/wiki/Deployment:-Nginx-&-uWSGI)
   - `circ-scripts`: a container that schedules and runs important cron jobs at recommended intervals
 
 To avoid database lockups, `circ-scripts` should be deployed as a single instance.
 
 ## Using This Image
 
-You will need **a PostgreSQL instance url** in the format `postgres://[username]:[password]@[host]:[port]/[database_name]`. With this URL, you can created containers for both the web application (`circ-deploy`) and for the background cron jobs that import and update books and otherwise keep the app running smoothly (`circ-scripts`). Either container can be used to initialize or migrate the database. During the first deployment against a brand new database, the first container run should be set with `SIMPLIFIED_DB_TASK='init'`. See the "Environment Variables" section below for mroe information.
+You will need **a PostgreSQL instance url** in the format `postgres://[username]:[password]@[host]:[port]/[database_name]`. With this URL, you can created containers for both the web application (`circ-webapp`) and for the background cron jobs that import and update books and otherwise keep the app running smoothly (`circ-scripts`). Either container can be used to initialize or migrate the database. During the first deployment against a brand new database, the first container run can use the default `SIMPLIFIED_DB_TASK='auto'` or be run manually with `SIMPLIFIED_DB_TASK='init'`. See the "Environment Variables" section below for mroe information.
 
-### circ-deploy
+### circ-webapp (**deprecated:** circ-deploy)
 
 ```
 # See the section "Environment Variables" below for more information
 # about the values listed here and their alternatives.
-$ docker run --name deploy \
+$ docker run --name webapp \
     -d -p 80:80 \
     -e SIMPLIFIED_DB_TASK='init' \
     -e SIMPLIFIED_PRODUCTION_DATABASE='postgres://[username]:[password]@[host]:[port]/[database_name]' \
-    nypl/circ-deploy:2.0
+    nypl/circ-webapp:2.0
 ```
 
 Navigate to `http://localhost/admin` to in your browser to input or update configuration information. If you have not yet created an admin authorization protocol before, you'll need to do that before you can set other configuration.
@@ -53,7 +53,7 @@ $ docker run --name scripts -d \
     nypl/circ-scripts:2.0
 ```
 
-Using `docker exec -it deploy /bin/bash` in your console, navigate to `/var/log/simplified` in the container. After 5-20 minutes, you'll begin to see log files populate that directory.
+Using `docker exec -it scripts /bin/bash` in your console, navigate to `/var/log/simplified` in the container. After 5-20 minutes, you'll begin to see log files populate that directory.
 
 For troubleshooting information and installation directions for the entire Circulation Manager tool suite, please review [the full deployment instructions](https://github.com/NYPL-Simplified/Simplified/wiki/Deployment:-Quickstart-with-Docker).
 
@@ -82,9 +82,9 @@ For troubleshooting information and installation directions for the entire Circu
 
 ## Building new images
 
-If you plan to work with stable versions of the Circulation Manager, we strongly recommend using the latest stable versions of circ-deploy and circ-scripts [published to Docker Hub](https://hub.docker.com/r/nypl/). However, there may come a time in development when you want to build Docker containers for a particular version of the Circulation Manager. If so, please use the instructions below.
+If you plan to work with stable versions of the Circulation Manager, we strongly recommend using the latest stable versions of circ-webapp and circ-scripts [published to Docker Hub](https://hub.docker.com/r/nypl/). However, there may come a time in development when you want to build Docker containers for a particular version of the Circulation Manager. If so, please use the instructions below.
 
-### > `.deploy` and `.scripts`
+### > `.webapp` and `.scripts`
 
 Determine which container you would like to build and update the tag and Dockerfile listed below accordingly.
 
@@ -110,7 +110,7 @@ We welcome your contributions to new features, fixes, or updates, large or small
 Before you start to code, we recommend discussing your plans through a [GitHub issue](https://github.com/NYPL-Simplified/circulation-docker/issues/new), especially for more ambitious contributions. This gives other contributors a chance to point you in the right direction, give you feedback on your design, and help you find out if someone else is working on the same thing.
 
 
-(**Note:** This README is intended to directly reflect [the documentation on Docker Hub](https://hub.docker.com/r/nypl/circ-deploy/).)
+(**Note:** This README is intended to directly reflect [the documentation on Docker Hub](https://hub.docker.com/r/nypl/circ-webapp/).)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ You will need **a PostgreSQL instance url** in the format `postgres://[username]
 # about the values listed here and their alternatives.
 $ docker run --name webapp \
     -d -p 80:80 \
-    -e SIMPLIFIED_DB_TASK='init' \
     -e SIMPLIFIED_PRODUCTION_DATABASE='postgres://[username]:[password]@[host]:[port]/[database_name]' \
     nypl/circ-webapp:2.0
 ```
@@ -48,7 +47,6 @@ For troubleshooting information and installation directions for the entire Circu
 # about the values listed here and their alternatives.
 $ docker run --name scripts -d \
     -e TZ='YOUR_TIMEZONE_STRING' \
-    -e SIMPLIFIED_DB_TASK='migrate' \
     -e SIMPLIFIED_PRODUCTION_DATABASE='postgres://[username]:[password]@[host]:[port]/[database_name]' \
     nypl/circ-scripts:2.0
 ```
@@ -59,13 +57,15 @@ For troubleshooting information and installation directions for the entire Circu
 
 ## Environment Variables
 
+Environment variables can be set with the `-e VARIABLE_KEY='variable_value'` option on the `docker run` command. `SIMPLIFIED_PRODUCTION_DATABASE` is the only required environment variable.
+
 ### `SIMPLIFIED_CONFIGURATION_FILE`
 
 *Optional.* The full path to a configuration file in the container. Configuration is now held in the database and accessed via an administrative interface at `/admin`, so you probably don't need this. If you do, use [this documentation](https://github.com/NYPL-Simplified/Simplified/wiki/Configuration) to create the JSON file for your particular library's configuration. If you're unfamiliar with JSON, you can use [this JSON Formatter & Validator](https://jsonformatter.curiousconcept.com/#) to validate your configuration file.
 
 ### `SIMPLIFIED_DB_TASK`
 
-*Required.* Performs a task against the database at container runtime. Options are:
+*Optional.* Performs a task against the database at container runtime. Options are:
   - `auto` : Either initializes or migrates the database, depending on if it is new or not. This is the default value.
   - `ignore` : Does nothing.
   - `init` : Initializes the app against a brand new database. If you are running a circulation manager for the first time every, use this value to set up an Elasticsearch alias and account for the database schema for future migrations.
@@ -79,6 +79,10 @@ For troubleshooting information and installation directions for the entire Circu
 ### `SIMPLIFIED_TEST_DATABASE`
 
 *Optional.* The URL of a PostgreSQL database for tests. This optional variable allows unit tests to be run in the container.
+
+### `TZ`
+
+*Optional. Applies to `circ-scripts` only.* The time zone that cron should use to run scheduled scripts--usually the time zone of the library or libraries on the circulation manager instance. This value should be selected according to [Debian-system time zone options](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones). This value allows scripts to be run at ideal times.
 
 ## Building new images
 


### PR DESCRIPTION
This branch introduces a Dockerfile to autogenerate `nypl/circ-webapp`, as mentioned in #65 and discussed in the #devops channel in the Library Simplified Slack on Wednesday, January 31st and Thursday, February 1st, 2018. The goal for the name change is to decrease any confusion around the purpose of the `circ-webapp` container, particularly in relation to the `circ-scripts` container. Thanks to @nodanaonlyzuul for the idea.

Both containers will coexist for a couple months, until nypl/circ-deploy is out of use by partner organizations.

This branch also updates the environment variable documentation around the recently-changed and now-optional `SIMPLIFIED_DB_TASK` and the somehow-lost-along-the-way `TZ`.

Resolves #65.