### PR TITLE
Add Odilo collection maintenance scripts to crontab

### DIFF
--- a/services/simplified_crontab
+++ b/services/simplified_crontab
@@ -90,3 +90,8 @@ HOME=/var/www/circulation
 0 6 * * * root core/bin/run odl_bibliographic_import_monitor >> /var/log/cron.log 2>&1
 0 6 * * * root core/bin/run odl_consolidated_copies_monitor >> /var/log/cron.log 2>&1
 0 */8 * * * root core/bin/run odl_hold_reaper >> /var/log/cron.log 2>&1
+
+# Odilo
+#
+0 */4 * * * root core/bin/run odilo_monitor_full >> /var/log/cron.log 2>&1
+*/15 * * * * root core/bin/run odilo_monitor_recent >> /var/log/cron.log 2>&1


### PR DESCRIPTION
These have been missing in previous versions of circulation.