### PR TITLE
Run circulation sweeps a small number of times per day

### DIFF
--- a/services/simplified_crontab
+++ b/services/simplified_crontab
@@ -51,12 +51,12 @@ HOME=/var/www/circulation
 # Axis 360
 #
 */15 * * * * root core/bin/run axis_monitor >> /var/log/cron.log 2>&1
-*/15 * * * * root core/bin/run axis_reaper >> /var/log/cron.log 2>&1
+0 4 * * * root core/bin/run axis_reaper >> /var/log/cron.log 2>&1
 
 # Bibliotheca
 #
 */15 * * * * root core/bin/run bibliotheca_monitor >> /var/log/cron.log 2>&1
-*/15 * * * * root core/bin/run bibliotheca_circulation_sweep >> /var/log/cron.log 2>&1
+0 5 * * * root core/bin/run bibliotheca_circulation_sweep >> /var/log/cron.log 2>&1
 
 # Overdrive
 #

--- a/services/simplified_crontab
+++ b/services/simplified_crontab
@@ -60,7 +60,7 @@ HOME=/var/www/circulation
 
 # Overdrive
 #
-*/15 * * * * root core/bin/run overdrive_monitor_full >> /var/log/cron.log 2>&1
+* */4 * * * root core/bin/run overdrive_monitor_full >> /var/log/cron.log 2>&1
 */15 * * * * root core/bin/run overdrive_monitor_recent >> /var/log/cron.log 2>&1
 */15 * * * * root core/bin/run overdrive_reaper >> /var/log/cron.log 2>&1
 0 4 * * * root core/bin/run overdrive_format_sweep >> /var/log/cron.log 2>&1

--- a/services/simplified_crontab
+++ b/services/simplified_crontab
@@ -60,7 +60,7 @@ HOME=/var/www/circulation
 
 # Overdrive
 #
-* */4 * * * root core/bin/run overdrive_monitor_full >> /var/log/cron.log 2>&1
+0 */4 * * * root core/bin/run overdrive_monitor_full >> /var/log/cron.log 2>&1
 */15 * * * * root core/bin/run overdrive_monitor_recent >> /var/log/cron.log 2>&1
 */15 * * * * root core/bin/run overdrive_reaper >> /var/log/cron.log 2>&1
 0 4 * * * root core/bin/run overdrive_format_sweep >> /var/log/cron.log 2>&1


### PR DESCRIPTION
This branch changes the Bibliotheca and Axis 360 circulation sweeps/reapers to run once a day, early in the morning. Overdrive's availability API is less reliable, so we should run that one several times a day. But in all these cases it's overkill to run the sweeps every fifteen minutes; the collections are likely to be too large to entirely process in fifteen minutes.