### PR TITLE
Update simplified_logrotate.conf

### DIFF
--- a/services/simplified_logrotate.conf
+++ b/services/simplified_logrotate.conf
@@ -1,4 +1,4 @@
-/var/log/simplified/* {
+/var/log/simplified/*.log {
     missingok
     daily
     create 0700 root root


### PR DESCRIPTION
I made a mistake in my last PR (#75) for logrotate. 

The * matches everything, including the rotated files, so it rotates the rotated files. Chaos ensues! 💣

I end up with log files like: 
`search_index_refresh.log-20180317.gz-20180320-20180322-20180324-20180326-20180328`

Tagging @courte to take a look.