### PR TITLE
Downgrade pip

### DIFF
--- a/simplified_app.sh
+++ b/simplified_app.sh
@@ -10,7 +10,7 @@ apt-get update && $minimal_apt_get_install python-dev \
   python2.7 \
   python-cairo \
   python-nose \
-  python-pip=9.0.3 \
+  python-setuptools \
   gcc \
   git \
   libpcre3 \
@@ -40,6 +40,7 @@ git submodule update --init --recursive
 printf "$(git describe --tags)" > .version
 
 # Use the latest version of pip to install a virtual environment for the app.
+easy_install pip==9.0.3
 pip install -U --no-cache-dir pip setuptools
 pip install --no-cache-dir virtualenv virtualenvwrapper
 virtualenv -p /usr/bin/python2.7 env

--- a/simplified_app.sh
+++ b/simplified_app.sh
@@ -10,7 +10,7 @@ apt-get update && $minimal_apt_get_install python-dev \
   python2.7 \
   python-cairo \
   python-nose \
-  python-pip \
+  python-pip=9.0.3 \
   gcc \
   git \
   libpcre3 \


### PR DESCRIPTION
The docker build seems to be failing with this error due to pip version 10:
```
+ pip install --no-cache-dir virtualenv virtualenvwrapper
Traceback (most recent call last):
File "/usr/bin/pip", line 9, in <module>
from pip import main
ImportError: cannot import name main
The command '/bin/sh -c /bin/bash -c "/ls_build/simplified_app.sh ${repo} ${version} && /ls_build/logrotate.sh && /ls_build/simplified_cron.sh && rm -rf /ls_build && /bd_build/cleanup.sh"' returned a non-zero code: 1
build hook failed! (1)
```

I don't think this is the best way to fix it but I did get successful builds in docker cloud. Still testing to make sure they actually work.