### PR TITLE
Install the setuptools APT package instead of pip. Install pip via easy_install instead of via APT package.

### DIFF
--- a/simplified_app.sh
+++ b/simplified_app.sh
@@ -10,7 +10,7 @@ apt-get update && $minimal_apt_get_install python-dev \
   python2.7 \
   python-cairo \
   python-nose \
-  python-pip \
+  python-setuptools \
   gcc \
   git \
   libpcre3 \
@@ -40,7 +40,7 @@ git submodule update --init --recursive
 printf "$(git describe --tags)" > .version
 
 # Use the latest version of pip to install a virtual environment for the app.
-pip install -U --no-cache-dir pip setuptools
+easy_install pip
 pip install --no-cache-dir virtualenv virtualenvwrapper
 virtualenv -p /usr/bin/python2.7 env
 


### PR DESCRIPTION
This is my suggested improvement to https://github.com/NYPL-Simplified/circulation-docker/pull/93. The main advantage is that we can continue to use the latest version of pip instead of pegging to an old version.