### PR TITLE
Adding novelist update script as a cron job.

### DIFF
--- a/services/simplified_crontab
+++ b/services/simplified_crontab
@@ -45,6 +45,9 @@ HOME=/var/www/circulation
 # If any works have out-of-date OPDS entries, rebuild them,
 40 22 * * * root core/bin/run opds_entry_coverage >> /var/log/cron.log 2>&1
 
+# Sync a library's collection with NoveList
+0 0 * * 0 root core/bin/run novelist_update >> /var/log/cron.log 2>&1
+
 # The remaining scripts keep the circulation manager in sync with
 # specific types of collections.
 


### PR DESCRIPTION
Part of [Circulation #957](https://github.com/NYPL-Simplified/circulation/pull/957). Adds a task to run the Novelist script.