### PR TITLE
Increase frequency of Enki import

### DIFF
--- a/services/simplified_crontab
+++ b/services/simplified_crontab
@@ -77,7 +77,7 @@ HOME=/var/www/circulation
 # Enki
 #
 0 0 1 * * root core/bin/run enki_reaper >> /var/log/cron.log 2>&1
-0 3 * * * root core/bin/run enki_import >> /var/log/cron.log 2>&1
+0 */6 * * * root core/bin/run enki_import >> /var/log/cron.log 2>&1
 
 # OPDS For Distributors
 #


### PR DESCRIPTION
In the event of a failure, it would be nice to be able to try again later in the day instead of waiting up to 24 hours.