### PR TITLE
Allow setting of elasticsearch version at runtime

### DIFF
--- a/Dockerfile.exec
+++ b/Dockerfile.exec
@@ -5,6 +5,7 @@ ARG version
 ARG repo="NYPL-Simplified/circulation"
 
 ENV SIMPLIFIED_DB_TASK "auto"
+ENV SIMPLIFIED_ELASTICSEARCH_VERSION 1
 ENV SIMPLIFIED_SCRIPT_NAME ""
 
 # Copy over all Library Simplified build files for this image

--- a/Dockerfile.scripts
+++ b/Dockerfile.scripts
@@ -5,7 +5,7 @@ ARG version
 ARG repo="NYPL-Simplified/circulation"
 
 ENV SIMPLIFIED_DB_TASK "auto"
-
+ENV SIMPLIFIED_ELASTICSEARCH_VERSION 1
 ENV TZ=US/Eastern
 
 # Copy over all Library Simplified build files for this image

--- a/Dockerfile.webapp
+++ b/Dockerfile.webapp
@@ -5,6 +5,7 @@ ARG version
 ARG repo="NYPL-Simplified/circulation"
 
 ENV SIMPLIFIED_DB_TASK "auto"
+ENV SIMPLIFIED_ELASTICSEARCH_VERSION 1
 
 # Copy over all Library Simplified build files for this image
 COPY . /ls_build

--- a/startup/03_elasticsearch_version.sh
+++ b/startup/03_elasticsearch_version.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -ex
+
+WORKDIR=/var/www/circulation
+su simplified <<EOF
+
+if [[ "$SIMPLIFIED_ELASTICSEARCH_VERSION" == "1" ]] || [[ "$SIMPLIFIED_ELASTICSEARCH_VERSION" == "6" ]]; then
+  # Enter the virtual environment for the application.
+  source $WORKDIR/env/bin/activate;
+
+  # Install ES libraries
+  pip install -r $WORKDIR/elasticsearch-requirements-$SIMPLIFIED_ELASTICSEARCH_VERSION.txt
+  echo "Using ElasticSearch $SIMPLIFIED_ELASTICSEARCH_VERSION";
+
+else 
+  echo "Unknown SIMPLIFIED_ELASTICSEARCH_VERSION '${SIMPLIFIED_ELASTICSEARCH_VERSION}' valid options are 1 or 6." && exit 127;
+
+fi;
+EOF


### PR DESCRIPTION
## Related Tickets / PRs

https://jira.nypl.org/browse/SIMPLY-1518
depends on: https://github.com/NYPL-Simplified/circulation/pull/1180

## What does this PR do?

Add a new script that is run when the container is started up that installs the correct version of the Elasticsearch libraries based on the `SIMPLIFIED_ELASTICSEARCH_VERSION` environment variable.

## Changes

If you don't set the `SIMPLIFIED_ELASTICSEARCH_VERSION` environment variable then this should behave the same as it did before and default to ES1.