### PR TITLE
Stagger the start times for certain scripts.

### DIFF
--- a/services/simplified_crontab
+++ b/services/simplified_crontab
@@ -22,19 +22,19 @@ HOME=/var/www/circulation
 30 3 * * * root core/bin/run update_nyt_bestseller_lists >> /var/log/cron.log 2>&1
 
 # Add newly discovered identifiers to our Metadata Wrangler collection.
-*/10 * * * * root core/bin/run metadata_wrangler_collection_registrar >> /var/log/cron.log 2>&1
+*/10 * * * * sleep $(($RANDOM % 3600)) && root core/bin/run metadata_wrangler_collection_registrar >> /var/log/cron.log 2>&1
 
 # Remove newly removed identifiers from our Metadata Wrangler collection
-0 */22 * * * root core/bin/run metadata_wrangler_collection_reaper >> /var/log/cron.log 2>&1
+0 */22 * * * sleep $(($RANDOM % 3600)) && root core/bin/run metadata_wrangler_collection_reaper >> /var/log/cron.log 2>&1
 
 # Check whether the Metadata Wrangler has ascertained any new
 # information about books in our collection.
-*/59 * * * * root core/bin/run metadata_wrangler_collection_updates >> /var/log/cron.log 2>&1
+*/59 * * * * sleep $(($RANDOM % 3600)) && root core/bin/run metadata_wrangler_collection_updates >> /var/log/cron.log 2>&1
 
 # If the Metadata Wrangler needs content such as book covers or distributor
 # information that only we can provide, send it over.
-30 21 * * * root core/bin/run metadata_upload_coverage >> /var/log/cron.log 2>&1
-0 3 * * 3 root core/bin/run metadata_wrangler_auxiliary_metadata >> /var/log/cron.log 2>&1
+30 21 * * * sleep $(($RANDOM % 3600)) && root core/bin/run metadata_upload_coverage >> /var/log/cron.log 2>&1
+0 3 * * 3 sleep $(($RANDOM % 3600)) && root core/bin/run metadata_wrangler_auxiliary_metadata >> /var/log/cron.log 2>&1
 
 # If any works are missing up-to-date presentation editions, add them.
 0 20 * * * root core/bin/run work_presentation_editions >> /var/log/cron.log 2>&1
@@ -54,7 +54,7 @@ HOME=/var/www/circulation
 0 2 * * * root core/bin/run database_reaper >> /var/log/cron.log 2>&1
 
 # Sync a library's collection with NoveList
-0 0 * * 0 root core/bin/run novelist_update >> /var/log/cron.log 2>&1
+0 0 * * 0 sleep $(($RANDOM % 3600)) && root core/bin/run novelist_update >> /var/log/cron.log 2>&1
 
 # Generate MARC files for libraries that have a MARC exporter configured.
 0 1 * * * root core/bin/run cache_marc_files >> /var/log/cron.log 2>&1

--- a/services/simplified_crontab
+++ b/services/simplified_crontab
@@ -22,14 +22,14 @@ HOME=/var/www/circulation
 30 3 * * * root core/bin/run update_nyt_bestseller_lists >> /var/log/cron.log 2>&1
 
 # Add newly discovered identifiers to our Metadata Wrangler collection.
-*/10 * * * * sleep $(($RANDOM % 3600)) && root core/bin/run metadata_wrangler_collection_registrar >> /var/log/cron.log 2>&1
+*/10 * * * * sleep $(($RANDOM % 540)) && root core/bin/run metadata_wrangler_collection_registrar >> /var/log/cron.log 2>&1
 
 # Remove newly removed identifiers from our Metadata Wrangler collection
-0 */22 * * * sleep $(($RANDOM % 3600)) && root core/bin/run metadata_wrangler_collection_reaper >> /var/log/cron.log 2>&1
+0 */22 * * * sleep $(($RANDOM % 3000)) && root core/bin/run metadata_wrangler_collection_reaper >> /var/log/cron.log 2>&1
 
 # Check whether the Metadata Wrangler has ascertained any new
 # information about books in our collection.
-*/59 * * * * sleep $(($RANDOM % 3600)) && root core/bin/run metadata_wrangler_collection_updates >> /var/log/cron.log 2>&1
+*/59 * * * * sleep $(($RANDOM % 3000)) && root core/bin/run metadata_wrangler_collection_updates >> /var/log/cron.log 2>&1
 
 # If the Metadata Wrangler needs content such as book covers or distributor
 # information that only we can provide, send it over.


### PR DESCRIPTION
This branch addresses https://jira.nypl.org/browse/SIMPLY-1835 by staggering the start times for certain scripts. My big concern is services for which these Docker images represent a significant fraction of the traffic, such that every circulation manager hitting the service at exactly the same time might overload it. Right now I think this means the metadata wrangler and NoveList.

I implemented this by adding a random sleep statement to the beginning of each script. I don't know how the `root` command works -- whether it's something we created or something that's part of Docker -- but assuming it's a normal shell command, this should work.

The sleep durations are calibrated for each script to guarantee them a reasonable amount of time to run before the next invocation of the crontab. Scripts that run once an hour sleep for up to 3000 seconds (50 minutes), scripts that run once a day (or less often) sleep for up to an hour, and the script that runs every ten minutes sleeps for up to nine minutes.