### PR TITLE
Added libpq-dev which seems to be required to install the latest version of psycopg2.

### DIFF
--- a/simplified_app.sh
+++ b/simplified_app.sh
@@ -17,7 +17,8 @@ apt-get update && $minimal_apt_get_install python-dev \
   libffi-dev \
   libjpeg-dev \
   nodejs \
-  npm
+  npm \
+  libpq-dev
 
 # Create a user.
 useradd -ms /bin/bash -U simplified


### PR DESCRIPTION
I think this will fix the docker builds, it built locally but I did not test the resulting image.