### PR TITLE
linking the nodejs folder to node.

### DIFF
--- a/simplified_app.sh
+++ b/simplified_app.sh
@@ -20,6 +20,8 @@ apt-get update && $minimal_apt_get_install python-dev \
   npm \
   libpq-dev
 
+ln /usr/bin/nodejs /usr/bin/node
+
 # Create a user.
 useradd -ms /bin/bash -U simplified
 


### PR DESCRIPTION
This is to help resolve [SIMPLY-1999](https://jira.nypl.org/browse/SIMPLY-1999).
I don't think this may be the best way to resolve this but it removes the `sh: 1: node: not found` error which stops the script.

I'm a bit confused because when I ran `docker-compose up` on this repo, the latest circulation-web version that the script was trying to install was not the latest one that is published. The version it did try to install did have the bootstrap version which installed a repo that required `node` for a command.  I'm not sure if there's a better way to update `nodejs` through `apt-get` since it seems that command is already getting the latests, right?