### PR TITLE
Wait longer for container to start up before checking service status

### DIFF
--- a/hooks/test
+++ b/hooks/test
@@ -48,7 +48,7 @@ function check_service_status()
 }
 
 # Wait for the container to start services before running tests
-sleep 20;
+sleep 30;
 
 # If this is an exec container, there are no tests to run.
 if [[ ${IMAGE_NAME} == *"exec"* ]]; then


### PR DESCRIPTION
Five of the fifteen Docker builds in the past month have failed their test hook: https://cloud.docker.com/u/nypl/repository/docker/nypl/circ-webapp/builds

We start up the freshly built Docker image, wait 20 seconds for the database initialization script to run and nginx to start up. Then we check for nginx, and it hasn't started up yet. Failure.

On successful builds, when nginx _has_ started up, we get to see how long nginx has been running. The output looks like this:

```
service_status='run: /etc/service/nginx: (pid 171) 2s'
```

In the recent successful builds, nginx has between 0 and 17 seconds of uptime. That's wildly variable, and "zero seconds of uptime" is right on the edge of failure. I feel like this process recently became slower, possibly for reasons related to Docker Hub's infrastructure, and bumping the sleep time up to 30 seconds will  fix it.

I can't be sure, though, without merging this branch, because I don't know how to trigger a Docker Hub build on anything other than circulation `master`.