### PR TITLE
Check the app server's heartbeat controller instead of trying to get an OPDS feed

### DIFF
--- a/hooks/test
+++ b/hooks/test
@@ -69,13 +69,13 @@ check_service_status /home/simplified/service/uwsgi
 docker exec -u postgres pg psql -U simplified -d docker_prod \
   -c "insert into libraries(name, short_name, uuid, is_default) values ('default', 'default', '1234', 't');";
 
-# Check to make sure the deployed app is running.
+# Make sure the web server is running.
 healthcheck=$(docker exec circ /bin/bash -c "curl --write-out \"%{http_code}\" --silent --output /dev/null http://localhost/healthcheck.html")
 if ! [[ ${healthcheck} == '200' ]]; then exit 1; else echo "  OK"; fi
 
-# And it's showing an OPDS feed.
-feed_type=$(docker exec circ /bin/bash -c "curl --write-out \"%{content_type}\" --silent --output /dev/null http://localhost/groups")
-if ! [[ ${feed_type} == 'application/atom+xml;profile=opds-catalog;kind=acquisition' ]]; then
+# Also make sure the app server is running.
+feed_type=$(docker exec circ /bin/bash -c "curl --write-out \"%{content_type}\" --silent --output /dev/null http://localhost/heartbeat")
+if ! [[ ${feed_type} == 'application/vnd.health+json' ]]; then
   exit 1
 else
   echo "  OK"

--- a/hooks/test
+++ b/hooks/test
@@ -66,6 +66,8 @@ check_service_status /etc/service/nginx
 check_service_status /home/simplified/service/uwsgi
 
 # Then create a library so the app will start.
+#
+# TODO: This is probably no longer necessary.
 docker exec -u postgres pg psql -U simplified -d docker_prod \
   -c "insert into libraries(name, short_name, uuid, is_default) values ('default', 'default', '1234', 't');";
 

--- a/services/simplified_crontab
+++ b/services/simplified_crontab
@@ -16,6 +16,7 @@ HOME=/var/www/circulation
 0 4 * * * root core/bin/run update_random_order >> /var/log/cron.log 2>&1
 */6 * * * * root core/bin/run search_index_refresh >> /var/log/cron.log 2>&1
 0 0 * * * root core/bin/run update_custom_list_size >> /var/log/cron.log 2>&1
+0 10 * * * root core/bin/run update_lane_size >> /var/log/cron.log 2>&1
 
 # These scripts improve the bibliographic information associated with
 # the collections.


### PR DESCRIPTION
The job of the heartbeat controller is to prove the app server is running. It's more reliable than /groups, since 3.0 can't generate an OPDS feed (even an empty one) if there's no Elasticsearch server configured.