### PR TITLE
Adding cheaper to dynamically scale workers

### DIFF
--- a/services/uwsgi.ini
+++ b/services/uwsgi.ini
@@ -29,9 +29,9 @@ buffer-size = 131072
 
 ; minimum of 2 workers at any time
 ; the master process will spawn and shut down workers as needed
-cheaper = 2
+cheaper = 3
 ; start off with four workers at start up
-cheaper-initial = 3
+cheaper-initial = 6
 ; increase by one worker if needed
 cheaper-step = 1
 ; algorithm to use to create a worker; spare is the default

--- a/services/uwsgi.ini
+++ b/services/uwsgi.ini
@@ -1,4 +1,6 @@
 [uwsgi]
+; necessary to gracefully re-spawn workers
+master = true
 # application's base folder
 base = /var/www/circulation
 home = %(base)/env
@@ -16,9 +18,26 @@ chmod-socket = 666
 logto = /var/log/uwsgi/%n.log
 log-format = %(addr) - - [%(ltime)] "%(method) %(uri) %(proto)" %(status) %(size) "%(referer)" "%(uagent)" host_hdr=%(host) req_time_elapsed=%(msecs)
 
-processes = 6
+; max number of workers; %k is the number of detected CPU cores
+processes = %(%k + 1)
 threads = 2
+; forcefully kill workers after 300s
 harakiri = 300
 lazy-apps = true
-touch-reload = %(base)/uwsgi.ini
+touch-workers-reload = %(base)/uwsgi.ini
 buffer-size = 131072
+
+; minimum of 2 workers at any time
+; the master process will spawn and shut down workers as needed
+cheaper = 2
+; start off with four workers at start up
+cheaper-initial = 3
+; increase by one worker if needed
+cheaper-step = 1
+; algorithm to use to create a worker; spare is the default
+cheaper-algo = spare
+; amount of time needed for uWSGI to spawn a new worker
+cheaper-overload = 30
+; timeout before reloading a worker in case it is running a request
+; 60 is the default
+worker-reload-mercy = 60


### PR DESCRIPTION
Spike investigation for [SIMPLY-967](https://jira.nypl.org/browse/SIMPLY-967). Adding cheaper to dynamically scale the number of workers for uWSGI.

Currently, these are settings found from the documentation and other recommended practices, such as [The Art of Reloading](https://uwsgi-docs.readthedocs.io/en/latest/articles/TheArtOfGracefulReloading.html). I am having nginx issues on local machine but am attempting this same setup for a local non-docker POC.