### PR TITLE
phusion/baseimage "latest" tag is now "latest-amd".

### DIFF
--- a/Dockerfile.exec
+++ b/Dockerfile.exec
@@ -1,4 +1,4 @@
-FROM phusion/baseimage
+FROM phusion/baseimage:latest-amd64
 MAINTAINER Library Simplified <info@librarysimplified.org>
 
 ARG version

--- a/Dockerfile.scripts
+++ b/Dockerfile.scripts
@@ -1,4 +1,4 @@
-FROM phusion/baseimage
+FROM phusion/baseimage:latest-amd64
 MAINTAINER Library Simplified <info@librarysimplified.org>
 
 ARG version

--- a/Dockerfile.webapp
+++ b/Dockerfile.webapp
@@ -1,4 +1,4 @@
-FROM phusion/baseimage
+FROM phusion/baseimage:latest-amd64
 MAINTAINER Library Simplified <info@librarysimplified.org>
 
 ARG version


### PR DESCRIPTION
Adjusting docker files to follow `phusion/baseimage` tag changes. Its latest amd64 image used to be tagged "latest", but is now tagged "latest-amd64".