### PR TITLE
Add LCP support

### DIFF
--- a/Dockerfile.exec
+++ b/Dockerfile.exec
@@ -1,5 +1,20 @@
+###############################################################################
+## lcpencrypt
+###############################################################################
+
+FROM amd64/golang AS builder
+
+LABEL maintainer="Library Simplified <info@librarysimplified.org>"
+
+RUN go get -v github.com/readium/readium-lcp-server/lcpencrypt
+
+###############################################################################
+## Final image
+###############################################################################
+
 FROM phusion/baseimage:latest-amd64
-MAINTAINER Library Simplified <info@librarysimplified.org>
+
+COPY --from=builder /go/bin/lcpencrypt /go/bin/lcpencrypt
 
 ARG version
 ARG repo="NYPL-Simplified/circulation"

--- a/Dockerfile.scripts
+++ b/Dockerfile.scripts
@@ -1,5 +1,20 @@
+###############################################################################
+## lcpencrypt
+###############################################################################
+
+FROM amd64/golang AS builder
+
+LABEL maintainer="Library Simplified <info@librarysimplified.org>"
+
+RUN go get -v github.com/readium/readium-lcp-server/lcpencrypt
+
+###############################################################################
+## Final image
+###############################################################################
+
 FROM phusion/baseimage:latest-amd64
-MAINTAINER Library Simplified <info@librarysimplified.org>
+
+COPY --from=builder /go/bin/lcpencrypt /go/bin/lcpencrypt
 
 ARG version
 ARG repo="NYPL-Simplified/circulation"


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

This PR adds [lcpencrypt binary](https://github.com/readium/readium-lcp-server/wiki/Encryption-tool) to `circ-scripts` and `circ-exec` Docker images.

Linked PRs:
- [PR # 1472](https://github.com/NYPL-Simplified/circulation/pull/1472) in `circulation`
- [PR # 1194](https://github.com/NYPL-Simplified/server_core/pull/1194) in `server_core`
- [PR # 279](https://github.com/NYPL-Simplified/opds-web-client/pull/279) in `opds-web-client`

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
